### PR TITLE
string overhaul

### DIFF
--- a/crates/shinran_config/src/config/parse/yaml.rs
+++ b/crates/shinran_config/src/config/parse/yaml.rs
@@ -18,7 +18,7 @@
  */
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_yaml_ng::Mapping;
 use std::convert::TryFrom;
 
@@ -26,7 +26,7 @@ use crate::util::is_yaml_empty;
 
 use super::ParsedConfig;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub(crate) struct YAMLConfig {
     #[serde(default)]
     pub label: Option<String>,

--- a/crates/shinran_config/src/matches/group/loader/mod.rs
+++ b/crates/shinran_config/src/matches/group/loader/mod.rs
@@ -19,6 +19,7 @@
 
 use anyhow::Result;
 use lazy_static::lazy_static;
+use shinran_types::StrArena;
 use std::path::Path;
 use thiserror::Error;
 
@@ -39,7 +40,10 @@ lazy_static! {
     static ref IMPORTER: YAMLImporter = YAMLImporter::new();
 }
 
-pub(crate) fn load_match_file(path: &Path) -> Result<(LoadedMatchFile, Option<NonFatalErrorSet>)> {
+pub(crate) fn load_match_file(
+    path: &Path,
+    str_arena: &mut StrArena,
+) -> Result<(LoadedMatchFile, Option<NonFatalErrorSet>)> {
     let Some(extension) = path.extension() else {
         return Err(LoadError::MissingExtension.into());
     };
@@ -48,7 +52,7 @@ pub(crate) fn load_match_file(path: &Path) -> Result<(LoadedMatchFile, Option<No
         return Err(LoadError::InvalidFormat.into());
     }
 
-    match IMPORTER.load_file(path) {
+    match IMPORTER.load_file(path, str_arena) {
         Ok((group, non_fatal_error_set)) => Ok((group, non_fatal_error_set)),
         Err(err) => Err(LoadError::ParsingError(err).into()),
     }
@@ -78,8 +82,9 @@ mod tests {
             let file = match_dir.join("base.invalid");
             std::fs::write(&file, "test").unwrap();
 
+            let mut str_arena = StrArena::new();
             assert!(matches!(
-                load_match_file(&file)
+                load_match_file(&file, &mut str_arena)
                     .unwrap_err()
                     .downcast::<LoadError>()
                     .unwrap(),
@@ -94,8 +99,9 @@ mod tests {
             let file = match_dir.join("base");
             std::fs::write(&file, "test").unwrap();
 
+            let mut str_arena = StrArena::new();
             assert!(matches!(
-                load_match_file(&file)
+                load_match_file(&file, &mut str_arena)
                     .unwrap_err()
                     .downcast::<LoadError>()
                     .unwrap(),
@@ -110,8 +116,9 @@ mod tests {
             let file = match_dir.join("base.yml");
             std::fs::write(&file, "test").unwrap();
 
+            let mut str_arena = StrArena::new();
             assert!(matches!(
-                load_match_file(&file)
+                load_match_file(&file, &mut str_arena)
                     .unwrap_err()
                     .downcast::<LoadError>()
                     .unwrap(),
@@ -134,8 +141,9 @@ mod tests {
             )
             .unwrap();
 
+            let mut str_arena = StrArena::new();
             assert_eq!(
-                load_match_file(&file)
+                load_match_file(&file, &mut str_arena)
                     .unwrap()
                     .0
                     .content
@@ -160,8 +168,9 @@ mod tests {
             )
             .unwrap();
 
+            let mut str_arena = StrArena::new();
             assert_eq!(
-                load_match_file(&file)
+                load_match_file(&file, &mut str_arena)
                     .unwrap()
                     .0
                     .content
@@ -186,8 +195,9 @@ mod tests {
             )
             .unwrap();
 
+            let mut str_arena = StrArena::new();
             assert_eq!(
-                load_match_file(&file)
+                load_match_file(&file, &mut str_arena)
                     .unwrap()
                     .0
                     .content

--- a/crates/shinran_config/src/matches/group/loader/yaml/parse.rs
+++ b/crates/shinran_config/src/matches/group/loader/yaml/parse.rs
@@ -17,7 +17,7 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::path::Path;
+use std::borrow::Cow;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -26,19 +26,19 @@ use serde_yaml_ng::Mapping;
 use crate::util::is_yaml_empty;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct YAMLMatchFile {
+pub struct YAMLMatchFile<'buffer> {
     #[serde(default)]
-    pub imports: Option<Vec<String>>,
+    pub imports: Option<Vec<Cow<'buffer, str>>>,
 
     #[serde(default)]
-    pub global_vars: Option<Vec<YAMLVariable>>,
+    pub global_vars: Option<Vec<YAMLVariable<'buffer>>>,
 
-    #[serde(default)]
-    pub matches: Option<Vec<YAMLMatch>>,
+    #[serde(default, borrow)]
+    pub matches: Option<Vec<YAMLMatch<'buffer>>>,
 }
 
-impl YAMLMatchFile {
-    pub fn parse_from_str(yaml: &str) -> Result<Self> {
+impl<'buffer> YAMLMatchFile<'buffer> {
+    pub fn parse_from_str(yaml: &'buffer str) -> Result<Self> {
         // Because an empty string is not valid YAML but we want to support it anyway
         if is_yaml_empty(yaml) {
             return Ok(serde_yaml_ng::from_str(
@@ -48,42 +48,36 @@ impl YAMLMatchFile {
 
         Ok(serde_yaml_ng::from_str(yaml)?)
     }
-
-    // TODO: test
-    pub fn parse_from_file(path: &Path) -> Result<Self> {
-        let content = std::fs::read_to_string(path)?;
-        Self::parse_from_str(&content)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct YAMLMatch {
+pub struct YAMLMatch<'buffer> {
     #[serde(default)]
-    pub label: Option<String>,
+    pub label: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
-    pub trigger: Option<String>,
+    pub trigger: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
-    pub triggers: Option<Vec<String>>,
+    pub triggers: Option<Vec<Cow<'buffer, str>>>,
 
     #[serde(default)]
-    pub regex: Option<String>,
+    pub regex: Option<Cow<'buffer, str>>,
+
+    #[serde(default, borrow)]
+    pub replace: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
-    pub replace: Option<String>,
+    pub image_path: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
-    pub image_path: Option<String>,
-
-    #[serde(default)]
-    pub form: Option<String>,
+    pub form: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
     pub form_fields: Option<Mapping>,
 
     #[serde(default)]
-    pub vars: Option<Vec<YAMLVariable>>,
+    pub vars: Option<Vec<YAMLVariable<'buffer>>>,
 
     #[serde(default)]
     pub word: Option<bool>,
@@ -98,33 +92,33 @@ pub struct YAMLMatch {
     pub propagate_case: Option<bool>,
 
     #[serde(default)]
-    pub uppercase_style: Option<String>,
+    pub uppercase_style: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
     pub force_clipboard: Option<bool>,
 
     #[serde(default)]
-    pub force_mode: Option<String>,
+    pub force_mode: Option<Cow<'buffer, str>>,
 
-    #[serde(default)]
-    pub markdown: Option<String>,
+    #[serde(default, borrow)]
+    pub markdown: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
     pub paragraph: Option<bool>,
 
-    #[serde(default)]
-    pub html: Option<String>,
+    #[serde(default, borrow)]
+    pub html: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
-    pub search_terms: Option<Vec<String>>,
+    pub search_terms: Option<Vec<Cow<'buffer, str>>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct YAMLVariable {
-    pub name: String,
+pub struct YAMLVariable<'buffer> {
+    pub name: Cow<'buffer, str>,
 
     #[serde(rename = "type")]
-    pub var_type: String,
+    pub var_type: Cow<'buffer, str>,
 
     #[serde(default = "default_params")]
     pub params: Mapping,
@@ -133,7 +127,7 @@ pub struct YAMLVariable {
     pub inject_vars: Option<bool>,
 
     #[serde(default)]
-    pub depends_on: Vec<String>,
+    pub depends_on: Vec<Cow<'buffer, str>>,
 }
 
 fn default_params() -> Mapping {

--- a/crates/shinran_config/src/matches/group/loader/yaml/parse.rs
+++ b/crates/shinran_config/src/matches/group/loader/yaml/parse.rs
@@ -20,12 +20,12 @@
 use std::borrow::Cow;
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_yaml_ng::Mapping;
 
 use crate::util::is_yaml_empty;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize)]
 pub struct YAMLMatchFile<'buffer> {
     #[serde(default)]
     pub imports: Option<Vec<Cow<'buffer, str>>>,
@@ -50,7 +50,7 @@ impl<'buffer> YAMLMatchFile<'buffer> {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize)]
 pub struct YAMLMatch<'buffer> {
     #[serde(default)]
     pub label: Option<Cow<'buffer, str>>,
@@ -64,7 +64,7 @@ pub struct YAMLMatch<'buffer> {
     #[serde(default)]
     pub regex: Option<Cow<'buffer, str>>,
 
-    #[serde(default, borrow)]
+    #[serde(default)]
     pub replace: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
@@ -100,20 +100,20 @@ pub struct YAMLMatch<'buffer> {
     #[serde(default)]
     pub force_mode: Option<Cow<'buffer, str>>,
 
-    #[serde(default, borrow)]
+    #[serde(default)]
     pub markdown: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
     pub paragraph: Option<bool>,
 
-    #[serde(default, borrow)]
+    #[serde(default)]
     pub html: Option<Cow<'buffer, str>>,
 
     #[serde(default)]
     pub search_terms: Option<Vec<Cow<'buffer, str>>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct YAMLVariable<'buffer> {
     pub name: Cow<'buffer, str>,
 

--- a/crates/shinran_config/src/matches/group/mod.rs
+++ b/crates/shinran_config/src/matches/group/mod.rs
@@ -18,7 +18,7 @@
  */
 
 use anyhow::Result;
-use shinran_types::{RegexMatch, TriggerMatch, Variable};
+use shinran_types::{RegexMatch, StrArena, TriggerMatch, Variable};
 use std::path::{Path, PathBuf};
 
 use crate::error::NonFatalErrorSet;
@@ -48,8 +48,11 @@ pub struct LoadedMatchFile {
 
 impl LoadedMatchFile {
     // TODO: test
-    pub fn load(file_path: &Path) -> Result<(Self, Option<NonFatalErrorSet>)> {
-        loader::load_match_file(file_path)
+    pub fn load(
+        file_path: &Path,
+        str_arena: &mut StrArena,
+    ) -> Result<(Self, Option<NonFatalErrorSet>)> {
+        loader::load_match_file(file_path, str_arena)
     }
 }
 

--- a/crates/shinran_types/src/lib.rs
+++ b/crates/shinran_types/src/lib.rs
@@ -2,6 +2,10 @@ use std::collections::HashMap;
 
 use enum_as_inner::EnumAsInner;
 
+mod str_arena;
+
+pub use str_arena::{StrArena, StrRef, StrVecRef};
+
 pub type StructId = i32;
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -152,7 +156,7 @@ impl Default for MatchEffect {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextEffect {
-    pub body: String,
+    pub body: StrRef,
     pub vars: Vec<Variable>,
     pub format: TextFormat,
     pub force_mode: Option<TextInjectMode>,
@@ -174,7 +178,7 @@ pub enum TextInjectMode {
 impl Default for TextEffect {
     fn default() -> Self {
         Self {
-            body: String::new(),
+            body: unsafe { StrRef::new(0, 0) },
             vars: Vec::new(),
             format: TextFormat::Plain,
             force_mode: None,

--- a/crates/shinran_types/src/str_arena.rs
+++ b/crates/shinran_types/src/str_arena.rs
@@ -1,0 +1,96 @@
+/// Reference to a string in the arena.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrRef {
+    start: usize,
+    end: usize,
+}
+
+impl StrRef {
+    /// Create a new `StrRef` from a start and end index.
+    ///
+    /// # Safety
+    /// The caller must ensure that `end` is greater than or equal to `start`,
+    /// and that the range `[start, end)` is a valid range in the arena.
+    pub unsafe fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+/// Reference to a vector of strings in the arena.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrVecRef {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct StrArena {
+    buf: String,
+}
+
+impl StrArena {
+    pub fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    /// Allocate a string in the arena.
+    pub fn alloc(&mut self, s: &str) -> StrRef {
+        let start = self.buf.len();
+        self.buf.push_str(s);
+        let end = self.buf.len();
+        StrRef { start, end }
+    }
+
+    /// Allocate a vector of strings in the arena.
+    ///
+    /// Returns `None` if any of the strings contain a newline character.
+    pub fn alloc_all(&mut self, strings: &[&str]) -> Option<StrVecRef> {
+        for s in strings {
+            if s.contains('\n') {
+                return None;
+            }
+        }
+        let start = self.buf.len();
+        for s in strings {
+            self.buf.push_str(s);
+            self.buf.push('\n');
+        }
+        // Remove the last newline character.
+        self.buf.pop();
+        let end = self.buf.len();
+        Some(StrVecRef { start, end })
+    }
+
+    pub fn get(&self, r: StrRef) -> &str {
+        &self.buf[r.start..r.end]
+    }
+
+    pub fn get_all(&self, r: StrVecRef) -> std::str::Split<'_, char> {
+        self.buf[r.start..r.end].split('\n')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_alloc() {
+        let mut arena = StrArena::new();
+        let r1 = arena.alloc("hello");
+        let r2 = arena.alloc("world");
+        assert_eq!(arena.get(r1), "hello");
+        assert_eq!(arena.get(r2), "world");
+    }
+
+    #[test]
+    fn test_alloc_all() {
+        let mut arena = StrArena::new();
+        let r = arena.alloc_all(&["hello", "world"]).unwrap();
+        let mut iter = arena.get_all(r);
+        assert_eq!(iter.next(), Some("hello"));
+        assert_eq!(iter.next(), Some("world"));
+        assert_eq!(iter.next(), None);
+    }
+}


### PR DESCRIPTION
**Status**:

- there are many problems
- one problem is that `TextEffect`, which has the body, is passed all the way through to the renderer; but there should be a step in the middle where the `StrRef` is turned into a `&'store str`
  * That step has to be in the cache, because before that point I can't have any references 
  * Actually, I can probably do this right before calling `render`
    - so, I'll re-introduce the `Template` struct 😆 
- the other problem is equality checks in the tests
  * This might be the biggest problem 