### PR TITLE
On-disk cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,7 +245,7 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -296,7 +307,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -316,6 +327,18 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -347,6 +370,34 @@ name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "calloop"
@@ -591,7 +642,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -612,7 +663,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -739,6 +790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +898,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -907,7 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1233,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1283,6 +1349,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1401,14 +1473,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
  "ptr_meta",
+ "rend",
  "rkyv_derive",
  "seahash",
+ "tinyvec",
+ "uuid",
 ]
 
 [[package]]
@@ -1485,7 +1573,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1496,7 +1584,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1537,6 +1625,7 @@ dependencies = [
  "mockall",
  "ordered-float",
  "regex",
+ "rkyv",
  "serde",
  "serde_yaml_ng",
  "shinran_helpers",
@@ -1578,6 +1667,7 @@ dependencies = [
  "log",
  "nucleo-matcher",
  "regex",
+ "rkyv",
  "serde",
  "serde_yaml_ng",
  "shinran_config",
@@ -1600,6 +1690,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "regex",
+ "rkyv",
  "shinran_types",
  "sys-locale",
  "thiserror",
@@ -1611,6 +1702,8 @@ version = "0.1.0"
 dependencies = [
  "compact_str",
  "enum-as-inner",
+ "regex",
+ "rkyv",
 ]
 
 [[package]]
@@ -1638,6 +1731,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1682,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1703,6 +1802,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -1749,7 +1854,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1784,6 +1889,21 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
@@ -1822,7 +1942,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1876,6 +1996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+
+[[package]]
 name = "value-bag"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +2050,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -1958,7 +2084,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2231,6 +2357,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ enum-as-inner = "0.6.0"
 tempdir = "0.3.7"
 dunce = "1.0.1"
 compact_str = { version = "0.8.0", features = ["serde", "rkyv"] }
+rkyv = { version = "0.7", features = ["size_32", "alloc", "std", "validation"] }

--- a/crates/shinran_config/Cargo.toml
+++ b/crates/shinran_config/Cargo.toml
@@ -23,6 +23,7 @@ walkdir = "2.3.1"
 ordered-float = "2.0"
 indoc = "1.0.3"
 compact_str.workspace = true
+rkyv.workspace = true
 
 [dev-dependencies]
 shinran_helpers = { path = "../shinran_helpers" }

--- a/crates/shinran_config/src/config/mod.rs
+++ b/crates/shinran_config/src/config/mod.rs
@@ -28,7 +28,8 @@ mod resolve;
 pub(crate) mod store;
 mod util;
 
-pub use resolve::{ProfileFile, ProfileId};
+pub use parse::{ArchivedParsedConfig, ParsedConfig};
+pub use resolve::{generate_match_paths, ProfileFile, ProfileId};
 pub use store::{LoadedProfileStore, ProfileRef, ProfileStore};
 
 // #[cfg(test)]

--- a/crates/shinran_config/src/config/parse/mod.rs
+++ b/crates/shinran_config/src/config/parse/mod.rs
@@ -18,13 +18,13 @@
  */
 
 use anyhow::Result;
-use rkyv::{Archive, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto, path::Path};
 use thiserror::Error;
 
 mod yaml;
 
-#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub(crate) struct ParsedConfig {
     pub label: Option<String>,

--- a/crates/shinran_config/src/config/parse/mod.rs
+++ b/crates/shinran_config/src/config/parse/mod.rs
@@ -26,7 +26,7 @@ mod yaml;
 
 #[derive(Debug, Clone, PartialEq, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
-pub(crate) struct ParsedConfig {
+pub struct ParsedConfig {
     pub label: Option<String>,
 
     pub backend: Option<String>,
@@ -79,8 +79,8 @@ pub(crate) struct ParsedConfig {
 }
 
 impl ParsedConfig {
-    pub fn load(path: &Path) -> Result<Self> {
-        let content = std::fs::read_to_string(path)?;
+    pub fn load(source_path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(source_path)?;
         match yaml::YAMLConfig::parse_from_str(&content) {
             Ok(config) => Ok(config.try_into()?),
             Err(err) => Err(ParsedConfigError::LoadFailed(err).into()),

--- a/crates/shinran_config/src/config/parse/mod.rs
+++ b/crates/shinran_config/src/config/parse/mod.rs
@@ -18,12 +18,14 @@
  */
 
 use anyhow::Result;
+use rkyv::{Archive, Serialize};
 use std::{collections::BTreeMap, convert::TryInto, path::Path};
 use thiserror::Error;
 
 mod yaml;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize)]
+#[archive(check_bytes)]
 pub(crate) struct ParsedConfig {
     pub label: Option<String>,
 

--- a/crates/shinran_config/src/config/resolve.rs
+++ b/crates/shinran_config/src/config/resolve.rs
@@ -37,7 +37,7 @@ use log::error;
 use regex::Regex;
 use rkyv::{
     with::{AsString, Map},
-    Archive, Serialize,
+    Archive, Deserialize, Serialize,
 };
 use shinran_types::RegexWrapper;
 use thiserror::Error;
@@ -45,7 +45,7 @@ use thiserror::Error;
 const STANDARD_INCLUDES: &[&str] = &["../match/**/[!_]*.yml"];
 pub type ProfileId = i32;
 
-#[derive(Debug, Clone, Default, Archive, Serialize)]
+#[derive(Debug, Clone, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct Filters {
     // TODO: Any config file with non-None filters should probably be ignored on Wayland.
@@ -180,12 +180,13 @@ impl LoadedProfileFile {
 }
 
 /// Struct representing one loaded configuration file.
-#[derive(Debug, Clone, Default, Archive, Serialize)]
+#[derive(Debug, Clone, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct ProfileFile {
     pub(crate) content: ParsedConfig,
 
-    // pub(crate) source_path: PathBuf,
+    #[with(AsString)]
+    pub(crate) source_path: PathBuf,
     pub(crate) match_file_paths: Vec<MatchFileRef>,
 
     pub(crate) filter: Filters,
@@ -207,7 +208,7 @@ impl ProfileFile {
 
         Self {
             content: loaded.content,
-            // source_path: loaded.source_path,
+            source_path: loaded.source_path,
             match_file_paths,
             filter: loaded.filter,
         }
@@ -218,9 +219,9 @@ impl ProfileFile {
             return label;
         }
 
-        // if let Some(source_path) = self.source_path.to_str() {
-        //     return source_path;
-        // }
+        if let Some(source_path) = self.source_path.to_str() {
+            return source_path;
+        }
 
         "none"
     }

--- a/crates/shinran_config/src/config/resolve.rs
+++ b/crates/shinran_config/src/config/resolve.rs
@@ -119,20 +119,16 @@ pub struct LoadedProfileFile {
 }
 
 impl LoadedProfileFile {
-    pub fn load_from_path(path: &Path, parent: Option<&Self>) -> Result<Self> {
-        let mut config = ParsedConfig::load(path)?;
+    pub fn load_from_path(source_path: &Path, parent: Option<&Self>) -> Result<Self> {
+        let mut config = ParsedConfig::load(source_path)?;
 
         // Inherit from the parent config if present
         if let Some(parent) = parent {
             inherit(&mut config, &parent.content);
         }
 
-        // Extract the base directory
-        let base_dir = path
-            .parent()
-            .ok_or_else(ResolveError::ParentResolveFailed)?;
-
-        let match_paths = generate_match_paths(&config, base_dir)
+        let match_paths = generate_match_paths(&config, source_path)
+            .ok_or_else(ResolveError::ParentResolveFailed)?
             .into_iter()
             .collect();
 
@@ -156,7 +152,7 @@ impl LoadedProfileFile {
 
         Ok(Self {
             content: config,
-            source_path: path.to_owned(),
+            source_path: source_path.to_owned(),
             match_file_paths: match_paths,
             filter: Filters {
                 title: filter_title.map(RegexWrapper::new),
@@ -183,10 +179,10 @@ impl LoadedProfileFile {
 #[derive(Debug, Clone, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct ProfileFile {
-    pub(crate) content: ParsedConfig,
+    pub content: ParsedConfig,
 
     #[with(AsString)]
-    pub(crate) source_path: PathBuf,
+    pub source_path: PathBuf,
     pub(crate) match_file_paths: Vec<MatchFileRef>,
 
     pub(crate) filter: Filters,
@@ -625,7 +621,7 @@ fn inherit(child: &mut ParsedConfig, parent: &ParsedConfig) {
 fn aggregate_includes(config: &ParsedConfig) -> HashSet<String> {
     let mut includes = HashSet::new();
 
-    if config.use_standard_includes.is_none() || config.use_standard_includes.unwrap() {
+    if config.use_standard_includes.is_none_or(|x| x) {
         for include in STANDARD_INCLUDES {
             includes.insert((*include).to_string());
         }
@@ -664,7 +660,10 @@ fn aggregate_excludes(config: &ParsedConfig) -> HashSet<String> {
     excludes
 }
 
-fn generate_match_paths(config: &ParsedConfig, base_dir: &Path) -> HashSet<PathBuf> {
+pub fn generate_match_paths(config: &ParsedConfig, source_path: &Path) -> Option<HashSet<PathBuf>> {
+    // Extract the base directory
+    let base_dir = source_path.parent()?;
+
     let includes = aggregate_includes(config);
     let excludes = aggregate_excludes(config);
 
@@ -672,10 +671,12 @@ fn generate_match_paths(config: &ParsedConfig, base_dir: &Path) -> HashSet<PathB
     let exclude_paths = calculate_paths(base_dir, excludes.iter());
     let include_paths = calculate_paths(base_dir, includes.iter());
 
-    include_paths
-        .difference(&exclude_paths)
-        .cloned()
-        .collect::<HashSet<_>>()
+    Some(
+        include_paths
+            .difference(&exclude_paths)
+            .cloned()
+            .collect::<HashSet<_>>(),
+    )
 }
 
 #[derive(Error, Debug)]

--- a/crates/shinran_config/src/config/store.rs
+++ b/crates/shinran_config/src/config/store.rs
@@ -28,9 +28,13 @@ use crate::{config::resolve::LoadedProfileFile, matches::group::MatchFileRef};
 use super::{ConfigStoreError, ProfileFile};
 use anyhow::{Context, Result};
 use log::{debug, error};
-use rkyv::{Archive, Serialize};
+use rkyv::{
+    string::ArchivedString,
+    with::{AsString, DeserializeWith},
+    Archive, Deserialize, Infallible, Serialize,
+};
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 #[repr(transparent)]
 pub struct ProfileStore {
@@ -83,6 +87,14 @@ impl ProfileStore {
         (0..self.profiles.len())
             .map(|idx| ProfileRef { idx })
             .collect()
+    }
+}
+
+impl ArchivedProfileStore {
+    pub fn get_source_paths(&self) -> impl Iterator<Item = &Path> {
+        self.profiles
+            .iter()
+            .map(|p| Path::new(p.source_path.as_str()))
     }
 }
 

--- a/crates/shinran_config/src/config/store.rs
+++ b/crates/shinran_config/src/config/store.rs
@@ -28,7 +28,10 @@ use crate::{config::resolve::LoadedProfileFile, matches::group::MatchFileRef};
 use super::{ConfigStoreError, ProfileFile};
 use anyhow::{Context, Result};
 use log::{debug, error};
+use rkyv::{Archive, Serialize};
 
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 #[repr(transparent)]
 pub struct ProfileStore {
     profiles: Vec<ProfileFile>,
@@ -165,6 +168,7 @@ impl LoadedProfileStore {
 #[cfg(test)]
 mod tests {
     use regex::Regex;
+    use shinran_types::RegexWrapper;
 
     use crate::config::parse::ParsedConfig;
 
@@ -191,7 +195,7 @@ mod tests {
         let default = new_mock("default");
         let custom1 = new_mock("custom1");
         let mut custom2 = new_mock("custom2");
-        custom2.filter.class = Some(Regex::new("foo").unwrap());
+        custom2.filter.class = Some(RegexWrapper::new(Regex::new("foo").unwrap()));
 
         let store = ProfileStore {
             profiles: vec![default, custom1, custom2],

--- a/crates/shinran_config/src/matches/group/loader/mod.rs
+++ b/crates/shinran_config/src/matches/group/loader/mod.rs
@@ -18,7 +18,7 @@
  */
 
 use anyhow::Result;
-use std::path::Path;
+use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::error::NonFatalErrorSet;
@@ -29,7 +29,9 @@ use super::LoadedMatchFile;
 
 pub(crate) mod yaml;
 
-pub(crate) fn load_match_file(path: &Path) -> Result<(LoadedMatchFile, Option<NonFatalErrorSet>)> {
+pub(crate) fn load_match_file(
+    path: PathBuf,
+) -> Result<(LoadedMatchFile, Option<NonFatalErrorSet>)> {
     let Some(extension) = path.extension() else {
         return Err(LoadError::MissingExtension.into());
     };
@@ -69,7 +71,7 @@ mod tests {
             std::fs::write(&file, "test").unwrap();
 
             assert!(matches!(
-                load_match_file(&file)
+                load_match_file(file)
                     .unwrap_err()
                     .downcast::<LoadError>()
                     .unwrap(),
@@ -85,7 +87,7 @@ mod tests {
             std::fs::write(&file, "test").unwrap();
 
             assert!(matches!(
-                load_match_file(&file)
+                load_match_file(file)
                     .unwrap_err()
                     .downcast::<LoadError>()
                     .unwrap(),
@@ -101,7 +103,7 @@ mod tests {
             std::fs::write(&file, "test").unwrap();
 
             assert!(matches!(
-                load_match_file(&file)
+                load_match_file(file)
                     .unwrap_err()
                     .downcast::<LoadError>()
                     .unwrap(),
@@ -125,7 +127,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                load_match_file(&file)
+                load_match_file(file)
                     .unwrap()
                     .0
                     .content
@@ -151,7 +153,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                load_match_file(&file)
+                load_match_file(file)
                     .unwrap()
                     .0
                     .content
@@ -177,7 +179,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                load_match_file(&file)
+                load_match_file(file)
                     .unwrap()
                     .0
                     .content

--- a/crates/shinran_config/src/matches/group/loader/yaml/mod.rs
+++ b/crates/shinran_config/src/matches/group/loader/yaml/mod.rs
@@ -144,10 +144,9 @@ pub fn try_convert_into_match(
     };
 
     // Make the field "uppercase_style" lower case in-place.
-    yaml_match
-        .uppercase_style
-        .as_mut()
-        .map(|s| s.make_ascii_lowercase());
+    if let Some(style) = yaml_match.uppercase_style.as_mut() {
+        style.make_ascii_lowercase()
+    };
 
     let uppercase_style = match yaml_match.uppercase_style.as_deref() {
         Some("uppercase") => UpperCasingStyle::Uppercase,

--- a/crates/shinran_config/src/matches/group/mod.rs
+++ b/crates/shinran_config/src/matches/group/mod.rs
@@ -18,6 +18,7 @@
  */
 use std::path::PathBuf;
 
+use rkyv::{Archive, Serialize};
 use shinran_types::{RegexMatch, TriggerMatch, Variable};
 
 pub(crate) mod loader;
@@ -26,7 +27,8 @@ mod path;
 /// Content of a match file.
 ///
 /// This struct owns the variables and matches, and is used to store the content of a match file.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct MatchFile {
     pub global_vars: Vec<Variable>,
     pub trigger_matches: Vec<TriggerMatch>,
@@ -48,7 +50,9 @@ pub struct MatchFileStore {
     files: Vec<LoadedMatchFile>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, Archive, Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Hash, PartialEq, Eq))]
 #[repr(transparent)]
 pub struct MatchFileRef {
     idx: usize,

--- a/crates/shinran_config/src/matches/group/mod.rs
+++ b/crates/shinran_config/src/matches/group/mod.rs
@@ -56,7 +56,13 @@ pub struct MatchFileStore {
 #[archive_attr(derive(Hash, PartialEq, Eq))]
 #[repr(transparent)]
 pub struct MatchFileRef {
-    idx: usize,
+    pub idx: usize,
+}
+
+impl PartialEq<usize> for MatchFileRef {
+    fn eq(&self, other: &usize) -> bool {
+        self.idx == *other
+    }
 }
 
 impl MatchFileStore {
@@ -78,5 +84,10 @@ impl MatchFileStore {
             .into_iter()
             .enumerate()
             .map(|(idx, elem)| (MatchFileRef { idx }, elem))
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.files.len()
     }
 }

--- a/crates/shinran_config/src/matches/group/mod.rs
+++ b/crates/shinran_config/src/matches/group/mod.rs
@@ -18,7 +18,7 @@
  */
 use std::path::PathBuf;
 
-use rkyv::{Archive, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 use shinran_types::{RegexMatch, TriggerMatch, Variable};
 
 pub(crate) mod loader;
@@ -27,7 +27,7 @@ mod path;
 /// Content of a match file.
 ///
 /// This struct owns the variables and matches, and is used to store the content of a match file.
-#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct MatchFile {
     pub global_vars: Vec<Variable>,
@@ -43,6 +43,7 @@ pub struct MatchFile {
 pub struct LoadedMatchFile {
     pub import_paths: Vec<PathBuf>,
     pub content: MatchFile,
+    pub source_path: PathBuf,
 }
 
 #[repr(transparent)]
@@ -50,7 +51,7 @@ pub struct MatchFileStore {
     files: Vec<LoadedMatchFile>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, Archive, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 #[archive_attr(derive(Hash, PartialEq, Eq))]
 #[repr(transparent)]

--- a/crates/shinran_config/src/matches/store/default.rs
+++ b/crates/shinran_config/src/matches/store/default.rs
@@ -53,8 +53,7 @@ impl ArchivedResolvedMatchFile {
 #[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct MatchStore {
-    // TODO: This HashMap should be a Vec, with the index being the MatchFileRef.
-    indexed_files: HashMap<MatchFileRef, ResolvedMatchFile>,
+    indexed_files: Box<[ResolvedMatchFile]>,
 }
 
 impl MatchStore {
@@ -74,7 +73,7 @@ impl MatchStore {
             &mut non_fatal_error_sets,
         );
 
-        let mut indexed_files = HashMap::new();
+        let mut indexed_files = Vec::with_capacity(loaded_files.len());
 
         for (path, match_file) in loaded_files.into_enumerate() {
             let imports = match_file
@@ -88,10 +87,17 @@ impl MatchStore {
                 content: match_file.content,
                 source_path: match_file.source_path,
             };
-            indexed_files.insert(path, indexed_file);
+            assert_eq!(path, indexed_files.len());
+            indexed_files.push(indexed_file);
         }
 
-        (Self { indexed_files }, match_file_map, non_fatal_error_sets)
+        (
+            Self {
+                indexed_files: indexed_files.into_boxed_slice(),
+            },
+            match_file_map,
+            non_fatal_error_sets,
+        )
     }
 
     /// Returns all matches and global vars that were defined in the given paths.
@@ -123,20 +129,20 @@ impl MatchStore {
     }
 
     pub fn loaded_paths(&self) -> Vec<MatchFileRef> {
-        self.indexed_files.keys().copied().collect()
+        (0..self.indexed_files.len())
+            .map(|idx| MatchFileRef { idx })
+            .collect()
     }
 }
 
 impl ArchivedMatchStore {
     pub fn get_source_paths(&self) -> impl Iterator<Item = &Path> {
-        self.indexed_files
-            .iter()
-            .map(|(_, file)| file.get_source_path())
+        self.indexed_files.iter().map(|file| file.get_source_path())
     }
 }
 
 fn query_matches_for_paths<'store>(
-    indexed_files: &'store HashMap<MatchFileRef, ResolvedMatchFile>,
+    indexed_files: &'store [ResolvedMatchFile],
     visited_paths: &mut HashSet<MatchFileRef>,
     visited_trigger_matches: &mut Vec<&'store TriggerMatch>,
     visited_regex_matches: &mut Vec<&'store RegexMatch>,
@@ -150,7 +156,7 @@ fn query_matches_for_paths<'store>(
 
         visited_paths.insert(*path);
 
-        let file = indexed_files.get(path).unwrap();
+        let file = &indexed_files[path.idx];
         visited_trigger_matches.extend(file.content.trigger_matches.iter());
         visited_regex_matches.extend(file.content.regex_matches.iter());
         visited_global_vars.extend(file.content.global_vars.iter());
@@ -308,19 +314,14 @@ mod tests {
             assert_eq!(non_fatal_error_sets.len(), 0);
             assert_eq!(match_store.indexed_files.len(), 3);
 
-            let base_group = &match_store
-                .indexed_files
-                .get(file_map.get(&base_file).unwrap())
-                .unwrap()
+            let base_group = &match_store.indexed_files[file_map.get(&base_file).unwrap().idx]
                 .content
                 .trigger_matches;
 
             assert_eq!(base_group, &create_matches(&[("hello", "world")]));
 
-            let another_group = &match_store
-                .indexed_files
-                .get(file_map.get(&another_file).unwrap())
-                .unwrap()
+            let another_group = &match_store.indexed_files
+                [file_map.get(&another_file).unwrap().idx]
                 .content
                 .trigger_matches;
             assert_eq!(
@@ -328,10 +329,7 @@ mod tests {
                 &create_matches(&[("hello", "world2"), ("foo", "bar")])
             );
 
-            let sub_group = &match_store
-                .indexed_files
-                .get(file_map.get(&sub_file).unwrap())
-                .unwrap()
+            let sub_group = &match_store.indexed_files[file_map.get(&sub_file).unwrap().idx]
                 .content
                 .trigger_matches;
             assert_eq!(sub_group, &create_matches(&[("hello", "world3")]));

--- a/crates/shinran_config/src/matches/store/default.rs
+++ b/crates/shinran_config/src/matches/store/default.rs
@@ -22,6 +22,7 @@ use crate::{
     matches::group::{loader, MatchFile, MatchFileRef, MatchFileStore},
 };
 use anyhow::Context;
+use rkyv::{Archive, Serialize};
 use shinran_types::{MatchesAndGlobalVars, RegexMatch, TriggerMatch, Variable};
 use std::{
     collections::{HashMap, HashSet},
@@ -31,7 +32,8 @@ use std::{
 /// Struct representing a match file, where all imports have been resolved.
 ///
 /// In contrast, a [`LoadedMatchFile`] contains unresolved imports.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct ResolvedMatchFile {
     imports: Vec<MatchFileRef>,
     content: MatchFile,
@@ -40,6 +42,8 @@ pub struct ResolvedMatchFile {
 /// The MatchStore contains all matches that we have loaded.
 ///
 /// We have a hash map of all match files, indexed by their file system path.
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct MatchStore {
     // TODO: This HashMap should be a Vec, with the index being the MatchFileRef.
     indexed_files: HashMap<MatchFileRef, ResolvedMatchFile>,

--- a/crates/shinran_config/src/matches/store/mod.rs
+++ b/crates/shinran_config/src/matches/store/mod.rs
@@ -17,21 +17,5 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{collections::HashMap, path::PathBuf};
-
-use crate::error::NonFatalErrorSet;
-
 mod default;
 pub use default::MatchStore;
-
-use super::group::MatchFileRef;
-
-pub fn load(
-    paths: &[PathBuf],
-) -> (
-    MatchStore,
-    HashMap<PathBuf, MatchFileRef>,
-    Vec<NonFatalErrorSet>,
-) {
-    default::MatchStore::load(paths)
-}

--- a/crates/shinran_ibus/src/engine.rs
+++ b/crates/shinran_ibus/src/engine.rs
@@ -71,7 +71,8 @@ impl ShinranEngine {
         let backend = self.backend.clone();
         // TODO: Investigate whether this can be done without cloning the text.
         let trigger = self.text.clone();
-        // `fuzzy_match` is a long-running CPU-bound operation, so we use `spawn_blocking`.
+        // `fuzzy_match` is a long-running CPU-bound operation, so we use `spawn_blocking`,
+        // because we don't want to block the async runtime.
         let candidates = task::spawn_blocking(move || backend.fuzzy_match(&trigger)).await;
 
         if !candidates.is_empty() {

--- a/crates/shinran_lib/Cargo.toml
+++ b/crates/shinran_lib/Cargo.toml
@@ -18,6 +18,7 @@ log = { workspace = true }
 regex.workspace = true
 unicode-segmentation = "1.12.0"
 nucleo-matcher = "0.3.1"
+rkyv = { workspace = true }
 
 [dev-dependencies]
 shinran_helpers = { path = "../shinran_helpers" }

--- a/crates/shinran_lib/src/config.rs
+++ b/crates/shinran_lib/src/config.rs
@@ -1,11 +1,18 @@
-use std::collections::HashMap;
+use std::{alloc::Layout, collections::HashMap, ptr::NonNull};
 
 use log::info;
+use rkyv::{
+    ser::{serializers::AllocSerializer, ScratchSpace, Serializer},
+    with::AsStringError,
+    Archive, Fallible, Serialize,
+};
 use shinran_config::{config::ProfileStore, matches::store::MatchStore};
 
 use crate::{get_path_override, load, path};
 
 /// A struct containing all the information that was loaded from match files and config files.
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct Configuration {
     pub profile_store: ProfileStore,
     pub match_store: MatchStore,
@@ -38,10 +45,88 @@ impl Configuration {
         let packages_path = &paths.packages;
         let renderer = shinran_render::Renderer::new(base_path, &home_path, packages_path);
 
-        Configuration {
+        let cfg = Configuration {
             profile_store: config_result.profile_store,
             match_store: config_result.match_store,
             renderer,
+        };
+        // We can construct our serializer in much the same way as we always do
+        let mut serializer = MySerializer::<AllocSerializer<1024>>::default();
+        // then manually serialize our value
+        serializer.serialize_value(&cfg).unwrap();
+        // and finally, dig all the way down to our byte buffer
+        let bytes = serializer.into_inner().into_serializer().into_inner();
+        let archived = rkyv::check_archived_root::<Configuration>(&bytes[..]).unwrap();
+        cfg
+    }
+}
+
+// This will be our serializer wrappper, it just contains another serializer inside of it and
+// forwards everything down.
+struct MySerializer<S> {
+    inner: S,
+}
+
+impl<S> MySerializer<S> {
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+// The Fallible trait defines the error type for our serializer. This is our new error type that
+// will implement From<AsStringError>.
+impl<S: Fallible> Fallible for MySerializer<S> {
+    type Error = MySerializerError<S::Error>;
+}
+
+// Our Serializer impl just forwards everything down to the inner serializer.
+impl<S: Serializer> Serializer for MySerializer<S> {
+    #[inline]
+    fn pos(&self) -> usize {
+        self.inner.pos()
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.inner.write(bytes).map_err(MySerializerError::Inner)
+    }
+}
+
+// Our ScratchSpace impl just forwards everything down to the inner serializer.
+impl<S: ScratchSpace> ScratchSpace for MySerializer<S> {
+    unsafe fn push_scratch(&mut self, layout: Layout) -> Result<NonNull<[u8]>, Self::Error> {
+        self.inner
+            .push_scratch(layout)
+            .map_err(MySerializerError::Inner)
+    }
+    unsafe fn pop_scratch(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), Self::Error> {
+        self.inner
+            .pop_scratch(ptr, layout)
+            .map_err(MySerializerError::Inner)
+    }
+}
+
+// A Default implementation will make it easier to construct our serializer in some cases.
+impl<S: Default> Default for MySerializer<S> {
+    fn default() -> Self {
+        Self {
+            inner: S::default(),
         }
+    }
+}
+
+// This is our new error type. It has one variant for errors from the inner serializer, and one
+// variant for AsStringErrors.
+#[derive(Debug)]
+enum MySerializerError<E> {
+    Inner(E),
+    AsStringError,
+}
+
+// This is the crux of our new error type. Since it implements From<AsStringError>, we'll be able to
+// use our serializer with the AsString wrapper.
+impl<E> From<AsStringError> for MySerializerError<E> {
+    fn from(_: AsStringError) -> Self {
+        Self::AsStringError
     }
 }

--- a/crates/shinran_lib/src/lib.rs
+++ b/crates/shinran_lib/src/lib.rs
@@ -164,7 +164,7 @@ mod tests {
             "config_dir".to_string(),
             base_path.to_str().unwrap().to_string(),
         );
-        Configuration::new(&cli_overrides)
+        Configuration::new(&cli_overrides).0
     }
 
     #[test]

--- a/crates/shinran_render/Cargo.toml
+++ b/crates/shinran_render/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.19", features = ["unstable-locales"] }
 rand = "0.8.3"
 sys-locale = "0.1.0"
 compact_str.workspace = true
+rkyv.workspace = true
 
 [lints]
 workspace = true

--- a/crates/shinran_render/src/extension/date.rs
+++ b/crates/shinran_render/src/extension/date.rs
@@ -18,7 +18,7 @@
  */
 
 use chrono::{DateTime, Duration, Local, Locale};
-use rkyv::{Archive, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 use shinran_types::{Number, Params, Value};
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
@@ -27,7 +27,7 @@ use crate::{Extension, ExtensionOutput, ExtensionResult};
 //     fn get_system_locale(&self) -> String;
 // }
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct DateExtension {
     // fixed_date: Option<DateTime<Local>>,

--- a/crates/shinran_render/src/extension/date.rs
+++ b/crates/shinran_render/src/extension/date.rs
@@ -18,6 +18,7 @@
  */
 
 use chrono::{DateTime, Duration, Local, Locale};
+use rkyv::{Archive, Serialize};
 use shinran_types::{Number, Params, Value};
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
@@ -26,14 +27,17 @@ use crate::{Extension, ExtensionOutput, ExtensionResult};
 //     fn get_system_locale(&self) -> String;
 // }
 
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct DateExtension {
-    fixed_date: Option<DateTime<Local>>,
+    // fixed_date: Option<DateTime<Local>>,
 }
 
 #[allow(clippy::new_without_default)]
 impl DateExtension {
     pub fn new() -> Self {
-        Self { fixed_date: None }
+        // Self { fixed_date: None }
+        Self {}
     }
 }
 
@@ -43,8 +47,17 @@ impl Extension for DateExtension {
     }
 
     fn calculate(&self, _: &crate::Scope, params: &Params) -> crate::ExtensionResult {
-        let mut now = self.get_date();
+        self.calculate_with_date(&crate::Scope::default(), params, Local::now())
+    }
+}
 
+impl DateExtension {
+    fn calculate_with_date(
+        &self,
+        _: &crate::Scope,
+        params: &Params,
+        mut now: DateTime<Local>,
+    ) -> crate::ExtensionResult {
         // Compute the given offset
         let offset = params.get("offset");
         if let Some(Value::Number(Number::Integer(offset))) = offset {
@@ -65,16 +78,6 @@ impl Extension for DateExtension {
         };
 
         ExtensionResult::Success(ExtensionOutput::Single(date))
-    }
-}
-
-impl DateExtension {
-    fn get_date(&self) -> DateTime<Local> {
-        if let Some(fixed_date) = self.fixed_date {
-            fixed_date
-        } else {
-            Local::now()
-        }
     }
 
     fn format_date_with_locale(date: DateTime<Local>, format: &str, locale: Locale) -> String {
@@ -413,16 +416,15 @@ mod tests {
 
     #[test]
     fn date_formatted_correctly() {
-        let mut extension = DateExtension::new();
-        // extension.fixed_date = Some(Local.ymd(2014, 7, 8).and_hms(9, 10, 11));
-        extension.fixed_date = Some(Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap());
+        let extension = DateExtension::new();
+        let now = Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap();
 
         let param = vec![("format".to_string(), Value::String("%H:%M:%S".to_string()))]
             .into_iter()
             .collect::<Params>();
         assert_eq!(
             extension
-                .calculate(&HashMap::default(), &param)
+                .calculate_with_date(&HashMap::default(), &param, now)
                 .into_success()
                 .unwrap(),
             ExtensionOutput::Single("09:10:11".to_string())
@@ -431,9 +433,8 @@ mod tests {
 
     #[test]
     fn offset_works_correctly() {
-        let mut extension = DateExtension::new();
-        // extension.fixed_date = Some(Local.ymd(2014, 7, 8).and_hms(9, 10, 11));
-        extension.fixed_date = Some(Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap());
+        let extension = DateExtension::new();
+        let now = Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap();
 
         let param = vec![
             ("format".to_string(), Value::String("%H:%M:%S".to_string())),
@@ -444,7 +445,7 @@ mod tests {
         .collect::<Params>();
         assert_eq!(
             extension
-                .calculate(&HashMap::default(), &param)
+                .calculate_with_date(&HashMap::default(), &param, now)
                 .into_success()
                 .unwrap(),
             ExtensionOutput::Single("10:10:11".to_string())
@@ -453,9 +454,8 @@ mod tests {
 
     #[test]
     fn default_locale_works_correctly() {
-        let mut extension = DateExtension::new();
-        // extension.fixed_date = Some(Local.ymd(2014, 7, 8).and_hms(9, 10, 11));
-        extension.fixed_date = Some(Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap());
+        let extension = DateExtension::new();
+        let now = Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap();
 
         let param = vec![
             ("format".to_string(), Value::String("%A".to_string())),
@@ -465,7 +465,7 @@ mod tests {
         .collect::<Params>();
         assert_eq!(
             extension
-                .calculate(&HashMap::default(), &param)
+                .calculate_with_date(&HashMap::default(), &param, now)
                 .into_success()
                 .unwrap(),
             ExtensionOutput::Single("martedì".to_string())
@@ -474,9 +474,8 @@ mod tests {
 
     #[test]
     fn invalid_locale_should_default_to_en_us() {
-        let mut extension = DateExtension::new();
-        // extension.fixed_date = Some(Local.ymd(2014, 7, 8).and_hms(9, 10, 11));
-        extension.fixed_date = Some(Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap());
+        let extension = DateExtension::new();
+        let now = Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap();
 
         let param = vec![
             ("format".to_string(), Value::String("%A".to_string())),
@@ -486,7 +485,7 @@ mod tests {
         .collect::<Params>();
         assert_eq!(
             extension
-                .calculate(&HashMap::default(), &param)
+                .calculate_with_date(&HashMap::default(), &param, now)
                 .into_success()
                 .unwrap(),
             ExtensionOutput::Single("Tuesday".to_string())
@@ -495,9 +494,8 @@ mod tests {
 
     #[test]
     fn override_locale() {
-        let mut extension = DateExtension::new();
-        // extension.fixed_date = Some(Local.ymd(2014, 7, 8).and_hms(9, 10, 11));
-        extension.fixed_date = Some(Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap());
+        let extension = DateExtension::new();
+        let now = Local.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap();
 
         let param = vec![
             ("format".to_string(), Value::String("%A".to_string())),
@@ -507,7 +505,7 @@ mod tests {
         .collect::<Params>();
         assert_eq!(
             extension
-                .calculate(&HashMap::default(), &param)
+                .calculate_with_date(&HashMap::default(), &param, now)
                 .into_success()
                 .unwrap(),
             ExtensionOutput::Single("martedì".to_string())

--- a/crates/shinran_render/src/extension/echo.rs
+++ b/crates/shinran_render/src/extension/echo.rs
@@ -18,11 +18,11 @@
  */
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
-use rkyv::{Archive, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 use shinran_types::{Params, Value};
 use thiserror::Error;
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct EchoExtension {
     // alias: String,

--- a/crates/shinran_render/src/extension/echo.rs
+++ b/crates/shinran_render/src/extension/echo.rs
@@ -18,31 +18,35 @@
  */
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
+use rkyv::{Archive, Serialize};
 use shinran_types::{Params, Value};
 use thiserror::Error;
 
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct EchoExtension {
-    alias: String,
+    // alias: String,
 }
 
 #[allow(clippy::new_without_default)]
 impl EchoExtension {
     pub fn new() -> Self {
         Self {
-            alias: "echo".to_string(),
+            // alias: "echo".to_string(),
         }
     }
 
-    pub fn new_with_alias(alias: &str) -> Self {
-        Self {
-            alias: alias.to_string(),
-        }
-    }
+    // pub fn new_with_alias(alias: &str) -> Self {
+    //     Self {
+    //         alias: alias.to_string(),
+    //     }
+    // }
 }
 
 impl Extension for EchoExtension {
     fn name(&self) -> &str {
-        self.alias.as_str()
+        // self.alias.as_str()
+        "echo"
     }
 
     fn calculate(&self, _: &crate::Scope, params: &Params) -> crate::ExtensionResult {
@@ -95,12 +99,12 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn alias() {
-        let extension_with_alias = EchoExtension::new_with_alias("dummy");
-        let extension = EchoExtension::new();
+    // #[test]
+    // fn alias() {
+    //     let extension_with_alias = EchoExtension::new_with_alias("dummy");
+    //     let extension = EchoExtension::new();
 
-        assert_eq!(extension.name(), "echo");
-        assert_eq!(extension_with_alias.name(), "dummy");
-    }
+    //     assert_eq!(extension.name(), "echo");
+    //     assert_eq!(extension_with_alias.name(), "dummy");
+    // }
 }

--- a/crates/shinran_render/src/extension/random.rs
+++ b/crates/shinran_render/src/extension/random.rs
@@ -19,11 +19,11 @@
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
 use rand::seq::SliceRandom;
-use rkyv::{Archive, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 use shinran_types::{Params, Value};
 use thiserror::Error;
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct RandomExtension {}
 

--- a/crates/shinran_render/src/extension/random.rs
+++ b/crates/shinran_render/src/extension/random.rs
@@ -19,9 +19,12 @@
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
 use rand::seq::SliceRandom;
+use rkyv::{Archive, Serialize};
 use shinran_types::{Params, Value};
 use thiserror::Error;
 
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct RandomExtension {}
 
 #[allow(clippy::new_without_default)]

--- a/crates/shinran_render/src/extension/script.rs
+++ b/crates/shinran_render/src/extension/script.rs
@@ -24,12 +24,18 @@ use std::{
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
 use log::{info, warn};
+use rkyv::{with::AsString, Archive, Serialize};
 use shinran_types::{Params, Value};
 use thiserror::Error;
 
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct ScriptExtension {
+    #[with(AsString)]
     home_path: PathBuf,
+    #[with(AsString)]
     config_path: PathBuf,
+    #[with(AsString)]
     packages_path: PathBuf,
 }
 

--- a/crates/shinran_render/src/extension/script.rs
+++ b/crates/shinran_render/src/extension/script.rs
@@ -24,11 +24,11 @@ use std::{
 
 use crate::{Extension, ExtensionOutput, ExtensionResult};
 use log::{info, warn};
-use rkyv::{with::AsString, Archive, Serialize};
+use rkyv::{with::AsString, Archive, Deserialize, Serialize};
 use shinran_types::{Params, Value};
 use thiserror::Error;
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct ScriptExtension {
     #[with(AsString)]

--- a/crates/shinran_render/src/extension/shell.rs
+++ b/crates/shinran_render/src/extension/shell.rs
@@ -175,7 +175,7 @@ impl Default for Shell {
             Shell::Powershell
         } else if cfg!(target_os = "macos") {
             static DEFAULT_MACOS_SHELL: LazyLock<Option<MacShell>> =
-                LazyLock::new(|| determine_default_macos_shell());
+                LazyLock::new(determine_default_macos_shell);
 
             match *DEFAULT_MACOS_SHELL {
                 Some(MacShell::Bash) => Shell::Bash,

--- a/crates/shinran_render/src/extension/shell.rs
+++ b/crates/shinran_render/src/extension/shell.rs
@@ -17,7 +17,7 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use rkyv::{with::AsString, Archive, Serialize};
+use rkyv::{with::AsString, Archive, Deserialize, Serialize};
 use shinran_types::{Params, Value};
 use std::{
     collections::HashMap,
@@ -193,7 +193,7 @@ impl Default for Shell {
     }
 }
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct ShellExtension {
     #[with(AsString)]

--- a/crates/shinran_render/src/extension/shell.rs
+++ b/crates/shinran_render/src/extension/shell.rs
@@ -17,6 +17,7 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+use rkyv::{with::AsString, Archive, Serialize};
 use shinran_types::{Params, Value};
 use std::{
     collections::HashMap,
@@ -192,7 +193,10 @@ impl Default for Shell {
     }
 }
 
+#[derive(Archive, Serialize)]
+#[archive(check_bytes)]
 pub struct ShellExtension {
+    #[with(AsString)]
     config_path: PathBuf,
 }
 

--- a/crates/shinran_render/src/renderer/mod.rs
+++ b/crates/shinran_render/src/renderer/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use log::{error, warn};
 use regex::{Captures, Regex};
-use rkyv::{Archive, CheckBytes, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 use shinran_types::{MatchEffect, Params, TextEffect, Value, VarType, Variable};
 use thiserror::Error;
 
@@ -42,7 +42,7 @@ pub(crate) static VAR_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\{\{\s*((?P<name>\w+)(\.(?P<subname>(\w+)))?)\s*\}\}").unwrap());
 static WORD_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\w+)").unwrap());
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct Renderer<M: Archive + Extension = NoOpExtension> {
     date_extension: DateExtension,
@@ -53,7 +53,7 @@ pub struct Renderer<M: Archive + Extension = NoOpExtension> {
     mock_extension: M,
 }
 
-#[derive(Archive, Serialize)]
+#[derive(Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct NoOpExtension;
 
@@ -284,7 +284,7 @@ mod tests {
     use super::*;
     use std::{collections::HashMap, iter::FromIterator};
 
-    #[derive(Archive, Serialize)]
+    #[derive(Archive, Serialize, Deserialize)]
     #[archive(check_bytes)]
     struct MockExtension {}
 

--- a/crates/shinran_types/Cargo.toml
+++ b/crates/shinran_types/Cargo.toml
@@ -6,6 +6,8 @@ edition.workspace = true
 [dependencies]
 enum-as-inner.workspace = true
 compact_str.workspace = true
+rkyv.workspace = true
+regex.workspace = true
 
 [lints]
 workspace = true

--- a/crates/shinran_types/src/lib.rs
+++ b/crates/shinran_types/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use compact_str::CompactString;
 use enum_as_inner::EnumAsInner;
-use rkyv::{Archive, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 
 mod regex_wrapper;
 
@@ -10,7 +10,7 @@ pub use regex_wrapper::RegexWrapper;
 
 pub type StructId = i32;
 
-#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum VarType {
     Date,
@@ -26,7 +26,7 @@ pub enum VarType {
     Unresolved,
 }
 
-#[derive(Debug, Clone, PartialEq, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct Variable {
     pub name: String,
@@ -50,7 +50,7 @@ impl Default for Variable {
 
 pub type Params = HashMap<String, Value>;
 
-#[derive(Debug, Clone, PartialEq, EnumAsInner, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, EnumAsInner, Archive, Serialize, Deserialize)]
 // We have a recursive type, which requires some special handling
 #[archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))]
 #[archive(check_bytes)]
@@ -74,7 +74,7 @@ pub enum Value {
     ),
 }
 
-#[derive(Debug, Clone, PartialEq, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum Number {
     Integer(i64),
@@ -130,7 +130,7 @@ impl MatchCause {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Archive, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum WordBoundary {
     #[default]
@@ -150,7 +150,7 @@ pub struct TriggerCause {
     pub uppercase_style: UpperCasingStyle,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Archive, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum UpperCasingStyle {
     #[default]
@@ -166,7 +166,7 @@ pub struct RegexCause {
 
 // Effects
 
-#[derive(Debug, Clone, PartialEq, EnumAsInner, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, EnumAsInner, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum MatchEffect {
     None,
@@ -180,7 +180,7 @@ impl Default for MatchEffect {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct TextEffect {
     pub body: String,
@@ -189,7 +189,7 @@ pub struct TextEffect {
     pub force_mode: Option<TextInjectMode>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum TextFormat {
     Plain,
@@ -197,7 +197,7 @@ pub enum TextFormat {
     Html,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub enum TextInjectMode {
     Keys,
@@ -215,13 +215,13 @@ impl Default for TextEffect {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Archive, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct ImageEffect {
     pub path: String,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Archive, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct BaseMatch {
     // pub id: i32,
@@ -232,7 +232,7 @@ pub struct BaseMatch {
     pub search_terms: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Archive, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct TriggerMatch {
     pub base_match: BaseMatch,
@@ -243,7 +243,7 @@ pub struct TriggerMatch {
     pub word_boundary: WordBoundary,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Archive, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Archive, Serialize, Deserialize)]
 #[archive(check_bytes)]
 pub struct RegexMatch {
     pub base_match: BaseMatch,

--- a/crates/shinran_types/src/regex_wrapper.rs
+++ b/crates/shinran_types/src/regex_wrapper.rs
@@ -1,0 +1,64 @@
+use regex::Regex;
+use rkyv::{
+    string::{ArchivedString, StringResolver},
+    with::{ArchiveWith, AsString, AsStringError, DeserializeWith, SerializeWith},
+    Fallible, SerializeUnsized,
+};
+
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct RegexWrapper(Regex);
+
+/// A wrapper around a regex that can be serialized and deserialized with rkyv.
+impl RegexWrapper {
+    pub fn new(regex: Regex) -> Self {
+        Self(regex)
+    }
+
+    /// Returns the original string of this regex.
+    pub fn to_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns true if and only if there is a match for the regex anywhere in the haystack given.
+    pub fn is_match(&self, haystack: &str) -> bool {
+        self.0.is_match(haystack)
+    }
+}
+
+impl ArchiveWith<RegexWrapper> for AsString {
+    type Archived = ArchivedString;
+    type Resolver = StringResolver;
+
+    #[inline]
+    unsafe fn resolve_with(
+        field: &RegexWrapper,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        ArchivedString::resolve_from_str(field.to_str(), pos, resolver, out);
+    }
+}
+
+impl<S: Fallible + ?Sized> SerializeWith<RegexWrapper, S> for AsString
+where
+    S::Error: From<AsStringError>,
+    str: SerializeUnsized<S>,
+{
+    #[inline]
+    fn serialize_with(
+        field: &RegexWrapper,
+        serializer: &mut S,
+    ) -> Result<Self::Resolver, S::Error> {
+        ArchivedString::serialize_from_str(field.to_str(), serializer)
+    }
+}
+
+impl<D: Fallible + ?Sized> DeserializeWith<ArchivedString, RegexWrapper, D> for AsString {
+    #[inline]
+    fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<RegexWrapper, D::Error> {
+        // It's safe to unwrap here because we know it's a valid regex.
+        Ok(RegexWrapper(Regex::new(field.as_str()).unwrap()))
+    }
+}


### PR DESCRIPTION
Selectively deserializing sounds really cool, but for now I'll simply deserialize everything.

Left to do:

- [x] derive `Deserialize` for all the relevant structs
- [x] write a function which loads the cache from the runtime directory and which also finds out how old the cache is
  * as long as there is a cache file, it *always* be loaded, because we need to know the paths of all the YAML files
- [x] write a function to retrieve the paths to the config files from the cache
- [x] write a function which finds out the change time for all the YAML file paths we earlier found in the cache
- [x] write a function that finds all files that would be automatically loaded (all files in `match/` which don't start with an underscore?)
  * if there are *any* files there that the cache didn't know about, we invalidate the cache
- [x] decide when exactly to _write_ the cache file
  * previously, I thought it should be at the end of program run time, but then what if the config files changed in the meantime?